### PR TITLE
address warnings: Node.js 16 actions are deprecated.

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,5 +1,4 @@
 name: pages
-de
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+      - fix/github-actions-node-16-to-node-20
 permissions:
   packages: write
   contents: write

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,4 +1,5 @@
 name: pages
+de
 
 on:
   workflow_dispatch:
@@ -23,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: "16"
+          node-version: "20"
           cache: "npm"
           cache-dependency-path: frontend/package-lock.json
 
@@ -62,7 +63,7 @@ jobs:
       - uses: actions/setup-node@v3
         if: github.repository_owner == 'microsoft'
         with:
-          node-version: "14"
+          node-version: "20"
 
       - run: npm init -y
         if: github.repository_owner == 'microsoft'


### PR DESCRIPTION
 Please update the following actions to use Node.js 20:
actions/checkout@v3, actions/setup-node@v3, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.